### PR TITLE
LHP: add localhost with port selection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const SITES: Record<string, string | ((args: string) => string) | undefined> = {
 	crates: 'https://crates.io/search?q={q}',
 	javadoc: args => `https://docs.oracle.com/javase/8/docs/api/${args.replace(/\./g, '/')}.html`,
 	lh: 'http://localhost:3000',
+	lhp: 'http://localhost:{q}',
 	rust: 'https://doc.rust-lang.org/book/?search={q}',
 	
 	// Design


### PR DESCRIPTION
A little different from the current pattern, so happy to take ideas if there should be changes here.

Quite a lot I work with apps that aren't just bound to :3000, so I want to be able to quickly get to them. So I propose `!lhp <port>` (lhp for Localhost Port)