### PR TITLE
Fix: Quick Links Not Working

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ function handleRequest(request: Request) {
 			const joined = rest.join(' ');
 			const parsed = typeof site === 'function' ? site(joined) : site;
 
-			return Response.redirect(parsed.replace('{q}', encodeURIComponent(joined)), 301);
+			return Response.redirect(parsed.replace('{q}', joined), 301);
 		}
 	}
 


### PR DESCRIPTION
As mentioned in issue #44, the URL encoding isn't working, I tested a few things, and it appears services like Github do not un-URL encode the requests. So, I removed it, there are other ways to fix the issue, but this way seems to work the best. Closes #44
